### PR TITLE
Fix bug where grapple hook sticks to walls and ground

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -417,5 +417,9 @@ ASALocalRun/
 # MFractors (Xamarin productivity tool) working folder 
 .mfractor/
 
-
-385/.vscode/settings.json
+# Visual Studio Code
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json

--- a/.gitignore
+++ b/.gitignore
@@ -418,3 +418,4 @@ ASALocalRun/
 .mfractor/
 
 
+385/.vscode/settings.json

--- a/385/Assets/Scripts/FireGrappleHook.cs
+++ b/385/Assets/Scripts/FireGrappleHook.cs
@@ -120,7 +120,7 @@ public class FireGrappleHook : MonoBehaviour {
 
     private void OnTriggerEnter2D(Collider2D collider)
     {
-        if (collider.tag == "GrapplePoint")
+        if (collider.tag == Tags.TAG_GRAPPLE_POINT)
         {
             casting = false;
             Debug.Log("GrappleHook collided with GrapplePoint: " + collider.name);
@@ -136,12 +136,12 @@ public class FireGrappleHook : MonoBehaviour {
 	{
 		string colliderTag = collision.collider.tag;
 		// Don't check for collisions with the Player object
-		if (collision.collider.tag == "Player") 
+		if (colliderTag == Tags.TAG_PLAYER) 
 		{
 			Physics2D.IgnoreCollision (gameObject.GetComponent<Collider2D> (), collision.collider);
 		} 
 		// If the hook collides with the floor or a wall, reset
-		else if (colliderTag == "Ground" || colliderTag == "Floor & Wall") 
+		else if (colliderTag == Tags.TAG_GROUND || colliderTag == Tags.TAG_FLOOR_WALL) 
 		{
 			casting = false;
 		}

--- a/385/Assets/Scripts/FireGrappleHook.cs
+++ b/385/Assets/Scripts/FireGrappleHook.cs
@@ -134,11 +134,16 @@ public class FireGrappleHook : MonoBehaviour {
     // be initiated).
     void OnCollisionEnter2D(Collision2D collision)
 	{
+		string colliderTag = collision.collider.tag;
 		// Don't check for collisions with the Player object
 		if (collision.collider.tag == "Player") 
 		{
-			Physics2D.IgnoreCollision (gameObject.GetComponent<Collider2D>(), collision.collider);
-			return;
+			Physics2D.IgnoreCollision (gameObject.GetComponent<Collider2D> (), collision.collider);
+		} 
+		// If the hook collides with the floor or a wall, reset
+		else if (colliderTag == "Ground" || colliderTag == "Floor & Wall") 
+		{
+			casting = false;
 		}
 	}
 

--- a/385/Assets/Scripts/PlayerController.cs
+++ b/385/Assets/Scripts/PlayerController.cs
@@ -9,16 +9,6 @@ using Assets.Scripts;
 public class PlayerController : MonoBehaviour
 {
     /// <summary>
-    /// The tag of a collision that the Player has to be in contact with in order to jump
-    /// </summary>
-    private const string GROUND = "Ground";
-
-    /// <summary>
-    /// Tag given to all the ends of the grapple hooks
-    /// </summary>
-    private const string GRAPPLE_HOOK = "GrappleHook";
-
-    /// <summary>
     /// Which axis does the player use to strafe left and right on the ground, or adjust
     /// their velocity when swinging?
     /// </summary>
@@ -89,11 +79,11 @@ public class PlayerController : MonoBehaviour
     void OnCollisionEnter2D(Collision2D collide)
     {
         //any game objects tagged as Ground will allow the player to jump
-        if (collide.gameObject.tag == GROUND)
+        if (collide.gameObject.tag == Tags.TAG_GROUND)
         {
             onGround = true;
         }
-        else if (collide.gameObject.tag == GRAPPLE_HOOK)
+        else if (collide.gameObject.tag == Tags.TAG_GRAPPLE_HOOK)
         {
             Debug.Log("Oh no this player was hit with a grapple hook!");
         }
@@ -101,7 +91,7 @@ public class PlayerController : MonoBehaviour
 
     void OnCollisionExit2D(Collision2D collide)
     {
-        if (collide.gameObject.tag == GROUND)
+        if (collide.gameObject.tag == Tags.TAG_GROUND)
         {
             onGround = false;
         }

--- a/385/Assets/Scripts/Tags.cs
+++ b/385/Assets/Scripts/Tags.cs
@@ -1,0 +1,17 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public static class Tags {
+
+	public const string TAG_RESPAWN = "Respawn";
+	public const string TAG_FINISH = "Finish";
+	public const string TAG_EDITOR_ONLY = "EditorOnly";
+	public const string TAG_MAIN_CAMERA = "MainCamera";
+	public const string TAG_PLAYER = "Player";
+	public const string TAG_GAME_CONTROLLER = "GameController";
+	public const string TAG_FLOOR_WALL = "Floor & Wall";
+	public const string TAG_GROUND = "Ground";
+	public const string TAG_GRAPPLE_POINT = "GrapplePoint";
+	public const string TAG_GRAPPLE_HOOK = "GrappleHook";
+}

--- a/385/Assets/Scripts/Tags.cs.meta
+++ b/385/Assets/Scripts/Tags.cs.meta
@@ -1,0 +1,13 @@
+fileFormatVersion: 2
+guid: 8afafb75b55142f4dbe13f25247eae1a
+timeCreated: 1524174426
+licenseType: Free
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
- Firing at or past a wall or the ground will now result in the grappling hook colliding with the surface and then resetting, as though it had reached its endpoint
- Collision isn't ignored, but casting is set to false causing the hook to reset. 

**5 min**
