### PR TITLE
#25 Fixes two grapple hooks sticking to each other on collision

### DIFF
--- a/385/Assets/Scripts/FireGrappleHook.cs
+++ b/385/Assets/Scripts/FireGrappleHook.cs
@@ -140,9 +140,12 @@ public class FireGrappleHook : MonoBehaviour {
 		{
 			Physics2D.IgnoreCollision (gameObject.GetComponent<Collider2D> (), collision.collider);
 		} 
-		// If the hook collides with the floor or a wall, reset
-		else if (colliderTag == Tags.TAG_GROUND || colliderTag == Tags.TAG_FLOOR_WALL) 
+		// If the hook collides with the floor, a wall, or another player's hook, reset
+		else if (colliderTag == Tags.TAG_GROUND || colliderTag == Tags.TAG_FLOOR_WALL
+				|| colliderTag == Tags.TAG_GRAPPLE_HOOK)
 		{
+			// Log to know that collision between hooks occurred and that they didn't stick together
+			if (colliderTag == Tags.TAG_GRAPPLE_HOOK) Debug.Log("Hook-on-hook collision occurred");
 			casting = false;
 		}
 	}


### PR DESCRIPTION
Simply adds the GrappleHook tag to the list of tags to ignore collisions for. Logs a collision of hooks so you can be sure they collided if testing.

**30 seconds**
