### PR TITLE
Fix #26 Connecting/releasing to/from grapple points now works

### DIFF
--- a/385/Assets/Materials/WallPhysicsMaterial.physicsMaterial2D
+++ b/385/Assets/Materials/WallPhysicsMaterial.physicsMaterial2D
@@ -1,0 +1,10 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!62 &6200000
+PhysicsMaterial2D:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_Name: WallPhysicsMaterial
+  friction: 0.1
+  bounciness: 1.3

--- a/385/Assets/Materials/WallPhysicsMaterial.physicsMaterial2D.meta
+++ b/385/Assets/Materials/WallPhysicsMaterial.physicsMaterial2D.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: 835a265ac1f66ed4eb9c627baadaf1cc
+timeCreated: 1524557762
+licenseType: Free
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 6200000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/385/Assets/Scenes/GrappleThrow.unity
+++ b/385/Assets/Scenes/GrappleThrow.unity
@@ -178,6 +178,11 @@ Prefab:
       propertyPath: m_TagString
       value: Floor & Wall
       objectReference: {fileID: 0}
+    - target: {fileID: 61972783870502272, guid: ca37e0b2abe3b7a4484b7c84ec8f0889,
+        type: 2}
+      propertyPath: m_Material
+      value: 
+      objectReference: {fileID: 6200000, guid: 835a265ac1f66ed4eb9c627baadaf1cc, type: 2}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: ca37e0b2abe3b7a4484b7c84ec8f0889, type: 2}
   m_IsPrefabParent: 0
@@ -208,7 +213,7 @@ BoxCollider2D:
   m_GameObject: {fileID: 323371822}
   m_Enabled: 1
   m_Density: 1
-  m_Material: {fileID: 0}
+  m_Material: {fileID: 6200000, guid: 835a265ac1f66ed4eb9c627baadaf1cc, type: 2}
   m_IsTrigger: 0
   m_UsedByEffector: 0
   m_UsedByComposite: 0
@@ -284,6 +289,11 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 5
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!120 &370375311 stripped
+LineRenderer:
+  m_PrefabParentObject: {fileID: 120827344970177270, guid: 982b977e0e8b71f4fb49001bc2fa0086,
+    type: 2}
+  m_PrefabInternal: {fileID: 1834731940}
 --- !u!1001 &943760599
 Prefab:
   m_ObjectHideFlags: 0
@@ -539,6 +549,26 @@ Prefab:
       propertyPath: m_RootOrder
       value: 7
       objectReference: {fileID: 0}
+    - target: {fileID: 114272269268600046, guid: 982b977e0e8b71f4fb49001bc2fa0086,
+        type: 2}
+      propertyPath: HookFireDistance
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 114596187521871214, guid: 982b977e0e8b71f4fb49001bc2fa0086,
+        type: 2}
+      propertyPath: RopeLineRenderer
+      value: 
+      objectReference: {fileID: 370375311}
+    - target: {fileID: 120654509948481612, guid: 982b977e0e8b71f4fb49001bc2fa0086,
+        type: 2}
+      propertyPath: m_Enabled
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 120827344970177270, guid: 982b977e0e8b71f4fb49001bc2fa0086,
+        type: 2}
+      propertyPath: m_Enabled
+      value: 0
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: 982b977e0e8b71f4fb49001bc2fa0086, type: 2}
   m_IsPrefabParent: 0
@@ -607,6 +637,11 @@ Prefab:
       propertyPath: m_TagString
       value: Floor & Wall
       objectReference: {fileID: 0}
+    - target: {fileID: 61972783870502272, guid: ca37e0b2abe3b7a4484b7c84ec8f0889,
+        type: 2}
+      propertyPath: m_Material
+      value: 
+      objectReference: {fileID: 6200000, guid: 835a265ac1f66ed4eb9c627baadaf1cc, type: 2}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: ca37e0b2abe3b7a4484b7c84ec8f0889, type: 2}
   m_IsPrefabParent: 0
@@ -786,7 +821,7 @@ BoxCollider2D:
   m_GameObject: {fileID: 2066614416}
   m_Enabled: 1
   m_Density: 1
-  m_Material: {fileID: 0}
+  m_Material: {fileID: 6200000, guid: 835a265ac1f66ed4eb9c627baadaf1cc, type: 2}
   m_IsTrigger: 0
   m_UsedByEffector: 0
   m_UsedByComposite: 0

--- a/385/Assets/Scripts/FireGrappleHook.cs
+++ b/385/Assets/Scripts/FireGrappleHook.cs
@@ -25,12 +25,12 @@ public class FireGrappleHook : MonoBehaviour {
 	// Time taken for the object to travel from start to endPoint
 	public float castDuration = 6.0f;
 
-	// References to player x and y position
+	// References to player x, y, and z positions
 	private float playerX; 
 	private float playerY;
     private float playerZ;
 
-	// References to hook x and y position
+	// References to hook x, y, and z positions
 	private float hookX;
 	private float hookY;
     private float hookZ;
@@ -95,14 +95,15 @@ public class FireGrappleHook : MonoBehaviour {
         // Keep the LineRenderer attached to the Player object
         ropeLineRenderer.SetPositions(lineRendererVectors);
 
+		// Fire button not held
+		if (!(FireButton.IsButtonHeld ())) 
+		{
+			// Detach player from grapple point
+			GameObject.Find ("Player 1").GetComponent<RopeSystem> ().RopeAnchorPoint = null;
+		}
+
 		if (FireButton.IsButtonClicked() && !casting) 
 		{
-			// REMOVEE Vector3 playerVector = new Vector3 (playerX, playerY, playerZ);
-			// REMOVEE Vector3 mousePosVector = Camera.main.ScreenToWorldPoint(Input.mousePosition);
-
-			// REMOVEE Vector3 mouseClickVector =
-			//	new Vector3 (Input.mousePosition.x, Input.mousePosition.y, 0);
-
 			casting = true;
 
 			// Get the end point of the reticle
@@ -148,9 +149,9 @@ public class FireGrappleHook : MonoBehaviour {
         {
             casting = false;
             Debug.Log("GrappleHook collided with GrapplePoint: " + collider.name);
-            /* Player attaches to the point and starts swinging. Here we'll probably need to keep "casting" as true 
-			 * until the player lets go of the rope. Might need to return in this if block to prevent the hook from 
-			 * being reset to the Player coordinates (shouldn't happen until they let go of the swinging rope) */
+            
+			// Set RopeAnchorPoint in RopeSystem to be the Rigidbody2D of the GrapplePoint hit
+			GameObject.Find ("Player 1").GetComponent<RopeSystem> ().RopeAnchorPoint = collider.attachedRigidbody;
         }
     }
 

--- a/385/Assets/Scripts/RenderReticle.cs
+++ b/385/Assets/Scripts/RenderReticle.cs
@@ -38,7 +38,9 @@ public class RenderReticle : MonoBehaviour {
 
 	// Update is called once per frame
 	void Update () {
-		if (GameObject.Find ("GrappleHook").GetComponent<FireGrappleHook> ().casting) 
+		// Don't draw the reticle when the player is casting or attached to a grapple point
+		if (GameObject.Find ("GrappleHook").GetComponent<FireGrappleHook> ().casting ||
+			GameObject.Find ("Player 1").GetComponent<RopeSystem>().IsRopeConnected()) 
 		{
 			reticleLineRenderer.enabled = false;
 			GetComponent<SpriteRenderer> ().enabled = false;

--- a/385/Assets/Scripts/RopeSystem.cs
+++ b/385/Assets/Scripts/RopeSystem.cs
@@ -43,7 +43,7 @@ public class RopeSystem : MonoBehaviour
     /// <returns>True, if the anchor point of the rope is connected, or false if not.</returns>
     public bool IsRopeConnected()
     {
-        return RopeAnchorPoint != null;
+		return (RopeAnchorPoint != null);
     }
 
     /// <summary>


### PR DESCRIPTION
* Player now connects to a grapple point and starts swinging when they hit a GrapplePoint with their hook.
* Player will continue to swing as long as fire button is held (release the fire button to let go of the rope)
* Reticle disappears when swinging from a point.
* Changed the RopeSystem LineRenderer to use the GrappleHook game object's LineRenderer.
* Created a WallPhysicsMaterial PhysicsMaterial2D and applied it to the walls in the GrappleThrow scene. Swinging into a wall was causing the player to stick and very slowly slide down, so I made the friction low and gave it some bounciness. We can play around with these values to see what feels right.

**Estimated: 15** **Min: 10** **Max: 45** **Actual: 25**