### PR TITLE
Add support for UnityEvents for common player actions.

### DIFF
--- a/385/Assets/Prefabs/GrapplePoint.prefab
+++ b/385/Assets/Prefabs/GrapplePoint.prefab
@@ -22,6 +22,7 @@ GameObject:
   - component: {fileID: 58750260760092786}
   - component: {fileID: 212333106031373414}
   - component: {fileID: 50299554944659686}
+  - component: {fileID: 114373067657765630}
   m_Layer: 0
   m_Name: GrapplePoint
   m_TagString: GrapplePoint
@@ -77,6 +78,27 @@ CircleCollider2D:
   m_Offset: {x: 0, y: 0.01140213}
   serializedVersion: 2
   m_Radius: 0.28335786
+--- !u!114 &114373067657765630
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1450384412150496}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 33f333e8531478b4bbfbd4c2c628aaf8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  OnGrappleConnect:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
+      Culture=neutral, PublicKeyToken=null
+  OnGrappleDisconnect:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
+      Culture=neutral, PublicKeyToken=null
 --- !u!212 &212333106031373414
 SpriteRenderer:
   m_ObjectHideFlags: 1

--- a/385/Assets/Scenes/GrappleThrow.unity
+++ b/385/Assets/Scenes/GrappleThrow.unity
@@ -488,6 +488,16 @@ Prefab:
   m_Modification:
     m_TransformParent: {fileID: 0}
     m_Modifications:
+    - target: {fileID: 114373067657765630, guid: 354aebfb9f3934dfba7d06808a897841,
+        type: 2}
+      propertyPath: OnGrappleConnect.m_PersistentCalls.m_Calls.Array.size
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 114373067657765630, guid: 354aebfb9f3934dfba7d06808a897841,
+        type: 2}
+      propertyPath: OnGrappleDisconnect.m_PersistentCalls.m_Calls.Array.size
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 4243135063600338, guid: 354aebfb9f3934dfba7d06808a897841, type: 2}
       propertyPath: m_LocalPosition.x
       value: -4.026589
@@ -519,6 +529,70 @@ Prefab:
     - target: {fileID: 4243135063600338, guid: 354aebfb9f3934dfba7d06808a897841, type: 2}
       propertyPath: m_RootOrder
       value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 1450384412150496, guid: 354aebfb9f3934dfba7d06808a897841, type: 2}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 114373067657765630, guid: 354aebfb9f3934dfba7d06808a897841,
+        type: 2}
+      propertyPath: OnGrappleConnect.m_PersistentCalls.m_Calls.Array.data[0].m_Mode
+      value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: 114373067657765630, guid: 354aebfb9f3934dfba7d06808a897841,
+        type: 2}
+      propertyPath: OnGrappleConnect.m_PersistentCalls.m_Calls.Array.data[0].m_CallState
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 114373067657765630, guid: 354aebfb9f3934dfba7d06808a897841,
+        type: 2}
+      propertyPath: OnGrappleConnect.m_PersistentCalls.m_Calls.Array.data[0].m_Target
+      value: 
+      objectReference: {fileID: 2107789480}
+    - target: {fileID: 114373067657765630, guid: 354aebfb9f3934dfba7d06808a897841,
+        type: 2}
+      propertyPath: OnGrappleConnect.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
+      value: Log
+      objectReference: {fileID: 0}
+    - target: {fileID: 114373067657765630, guid: 354aebfb9f3934dfba7d06808a897841,
+        type: 2}
+      propertyPath: OnGrappleConnect.m_PersistentCalls.m_Calls.Array.data[0].m_Arguments.m_ObjectArgumentAssemblyTypeName
+      value: UnityEngine.Object, UnityEngine
+      objectReference: {fileID: 0}
+    - target: {fileID: 114373067657765630, guid: 354aebfb9f3934dfba7d06808a897841,
+        type: 2}
+      propertyPath: OnGrappleConnect.m_PersistentCalls.m_Calls.Array.data[0].m_Arguments.m_StringArgument
+      value: Grapple Point Connected!
+      objectReference: {fileID: 0}
+    - target: {fileID: 114373067657765630, guid: 354aebfb9f3934dfba7d06808a897841,
+        type: 2}
+      propertyPath: OnGrappleDisconnect.m_PersistentCalls.m_Calls.Array.data[0].m_Mode
+      value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: 114373067657765630, guid: 354aebfb9f3934dfba7d06808a897841,
+        type: 2}
+      propertyPath: OnGrappleDisconnect.m_PersistentCalls.m_Calls.Array.data[0].m_CallState
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 114373067657765630, guid: 354aebfb9f3934dfba7d06808a897841,
+        type: 2}
+      propertyPath: OnGrappleDisconnect.m_PersistentCalls.m_Calls.Array.data[0].m_Target
+      value: 
+      objectReference: {fileID: 2107789480}
+    - target: {fileID: 114373067657765630, guid: 354aebfb9f3934dfba7d06808a897841,
+        type: 2}
+      propertyPath: OnGrappleDisconnect.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
+      value: Log
+      objectReference: {fileID: 0}
+    - target: {fileID: 114373067657765630, guid: 354aebfb9f3934dfba7d06808a897841,
+        type: 2}
+      propertyPath: OnGrappleDisconnect.m_PersistentCalls.m_Calls.Array.data[0].m_Arguments.m_ObjectArgumentAssemblyTypeName
+      value: UnityEngine.Object, UnityEngine
+      objectReference: {fileID: 0}
+    - target: {fileID: 114373067657765630, guid: 354aebfb9f3934dfba7d06808a897841,
+        type: 2}
+      propertyPath: OnGrappleDisconnect.m_PersistentCalls.m_Calls.Array.data[0].m_Arguments.m_StringArgument
+      value: Grapple Point Disconnected!?
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: 354aebfb9f3934dfba7d06808a897841, type: 2}
@@ -728,6 +802,31 @@ Prefab:
   m_Modification:
     m_TransformParent: {fileID: 0}
     m_Modifications:
+    - target: {fileID: 114892520084136018, guid: 982b977e0e8b71f4fb49001bc2fa0086,
+        type: 2}
+      propertyPath: OnPlayerJump.m_PersistentCalls.m_Calls.Array.size
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 114892520084136018, guid: 982b977e0e8b71f4fb49001bc2fa0086,
+        type: 2}
+      propertyPath: OnPlayerLand.m_PersistentCalls.m_Calls.Array.size
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 114402239207182064, guid: 982b977e0e8b71f4fb49001bc2fa0086,
+        type: 2}
+      propertyPath: OnPlayerGrappleHit.m_PersistentCalls.m_Calls.Array.size
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 114402239207182064, guid: 982b977e0e8b71f4fb49001bc2fa0086,
+        type: 2}
+      propertyPath: OnPlayerGrappleFire.m_PersistentCalls.m_Calls.Array.size
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 114402239207182064, guid: 982b977e0e8b71f4fb49001bc2fa0086,
+        type: 2}
+      propertyPath: OnPlayerGrappleRelease.m_PersistentCalls.m_Calls.Array.size
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 4286566351652530, guid: 982b977e0e8b71f4fb49001bc2fa0086, type: 2}
       propertyPath: m_LocalPosition.x
       value: -1.8115573
@@ -764,6 +863,156 @@ Prefab:
         type: 2}
       propertyPath: ClimbDescendSpeed
       value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 114892520084136018, guid: 982b977e0e8b71f4fb49001bc2fa0086,
+        type: 2}
+      propertyPath: OnPlayerJump.m_PersistentCalls.m_Calls.Array.data[0].m_Mode
+      value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: 114892520084136018, guid: 982b977e0e8b71f4fb49001bc2fa0086,
+        type: 2}
+      propertyPath: OnPlayerJump.m_PersistentCalls.m_Calls.Array.data[0].m_CallState
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 114892520084136018, guid: 982b977e0e8b71f4fb49001bc2fa0086,
+        type: 2}
+      propertyPath: OnPlayerJump.m_PersistentCalls.m_Calls.Array.data[0].m_Target
+      value: 
+      objectReference: {fileID: 2107789480}
+    - target: {fileID: 114892520084136018, guid: 982b977e0e8b71f4fb49001bc2fa0086,
+        type: 2}
+      propertyPath: OnPlayerJump.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
+      value: Log
+      objectReference: {fileID: 0}
+    - target: {fileID: 114892520084136018, guid: 982b977e0e8b71f4fb49001bc2fa0086,
+        type: 2}
+      propertyPath: OnPlayerJump.m_PersistentCalls.m_Calls.Array.data[0].m_Arguments.m_ObjectArgumentAssemblyTypeName
+      value: UnityEngine.Object, UnityEngine
+      objectReference: {fileID: 0}
+    - target: {fileID: 114892520084136018, guid: 982b977e0e8b71f4fb49001bc2fa0086,
+        type: 2}
+      propertyPath: OnPlayerJump.m_PersistentCalls.m_Calls.Array.data[0].m_Arguments.m_StringArgument
+      value: Player Jumped!?
+      objectReference: {fileID: 0}
+    - target: {fileID: 114892520084136018, guid: 982b977e0e8b71f4fb49001bc2fa0086,
+        type: 2}
+      propertyPath: OnPlayerLand.m_PersistentCalls.m_Calls.Array.data[0].m_Mode
+      value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: 114892520084136018, guid: 982b977e0e8b71f4fb49001bc2fa0086,
+        type: 2}
+      propertyPath: OnPlayerLand.m_PersistentCalls.m_Calls.Array.data[0].m_CallState
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 114892520084136018, guid: 982b977e0e8b71f4fb49001bc2fa0086,
+        type: 2}
+      propertyPath: OnPlayerLand.m_PersistentCalls.m_Calls.Array.data[0].m_Target
+      value: 
+      objectReference: {fileID: 2107789480}
+    - target: {fileID: 114892520084136018, guid: 982b977e0e8b71f4fb49001bc2fa0086,
+        type: 2}
+      propertyPath: OnPlayerLand.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
+      value: Log
+      objectReference: {fileID: 0}
+    - target: {fileID: 114892520084136018, guid: 982b977e0e8b71f4fb49001bc2fa0086,
+        type: 2}
+      propertyPath: OnPlayerLand.m_PersistentCalls.m_Calls.Array.data[0].m_Arguments.m_ObjectArgumentAssemblyTypeName
+      value: UnityEngine.Object, UnityEngine
+      objectReference: {fileID: 0}
+    - target: {fileID: 114892520084136018, guid: 982b977e0e8b71f4fb49001bc2fa0086,
+        type: 2}
+      propertyPath: OnPlayerLand.m_PersistentCalls.m_Calls.Array.data[0].m_Arguments.m_StringArgument
+      value: Player Landed!! WOW!!!
+      objectReference: {fileID: 0}
+    - target: {fileID: 114402239207182064, guid: 982b977e0e8b71f4fb49001bc2fa0086,
+        type: 2}
+      propertyPath: OnPlayerGrappleFire.m_PersistentCalls.m_Calls.Array.data[0].m_Mode
+      value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: 114402239207182064, guid: 982b977e0e8b71f4fb49001bc2fa0086,
+        type: 2}
+      propertyPath: OnPlayerGrappleFire.m_PersistentCalls.m_Calls.Array.data[0].m_CallState
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 114402239207182064, guid: 982b977e0e8b71f4fb49001bc2fa0086,
+        type: 2}
+      propertyPath: OnPlayerGrappleFire.m_PersistentCalls.m_Calls.Array.data[0].m_Target
+      value: 
+      objectReference: {fileID: 2107789480}
+    - target: {fileID: 114402239207182064, guid: 982b977e0e8b71f4fb49001bc2fa0086,
+        type: 2}
+      propertyPath: OnPlayerGrappleFire.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
+      value: Log
+      objectReference: {fileID: 0}
+    - target: {fileID: 114402239207182064, guid: 982b977e0e8b71f4fb49001bc2fa0086,
+        type: 2}
+      propertyPath: OnPlayerGrappleFire.m_PersistentCalls.m_Calls.Array.data[0].m_Arguments.m_ObjectArgumentAssemblyTypeName
+      value: UnityEngine.Object, UnityEngine
+      objectReference: {fileID: 0}
+    - target: {fileID: 114402239207182064, guid: 982b977e0e8b71f4fb49001bc2fa0086,
+        type: 2}
+      propertyPath: OnPlayerGrappleFire.m_PersistentCalls.m_Calls.Array.data[0].m_Arguments.m_StringArgument
+      value: FIRE!
+      objectReference: {fileID: 0}
+    - target: {fileID: 114402239207182064, guid: 982b977e0e8b71f4fb49001bc2fa0086,
+        type: 2}
+      propertyPath: OnPlayerGrappleHit.m_PersistentCalls.m_Calls.Array.data[0].m_Mode
+      value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: 114402239207182064, guid: 982b977e0e8b71f4fb49001bc2fa0086,
+        type: 2}
+      propertyPath: OnPlayerGrappleHit.m_PersistentCalls.m_Calls.Array.data[0].m_CallState
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 114402239207182064, guid: 982b977e0e8b71f4fb49001bc2fa0086,
+        type: 2}
+      propertyPath: OnPlayerGrappleHit.m_PersistentCalls.m_Calls.Array.data[0].m_Target
+      value: 
+      objectReference: {fileID: 2107789480}
+    - target: {fileID: 114402239207182064, guid: 982b977e0e8b71f4fb49001bc2fa0086,
+        type: 2}
+      propertyPath: OnPlayerGrappleHit.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
+      value: Log
+      objectReference: {fileID: 0}
+    - target: {fileID: 114402239207182064, guid: 982b977e0e8b71f4fb49001bc2fa0086,
+        type: 2}
+      propertyPath: OnPlayerGrappleHit.m_PersistentCalls.m_Calls.Array.data[0].m_Arguments.m_ObjectArgumentAssemblyTypeName
+      value: UnityEngine.Object, UnityEngine
+      objectReference: {fileID: 0}
+    - target: {fileID: 114402239207182064, guid: 982b977e0e8b71f4fb49001bc2fa0086,
+        type: 2}
+      propertyPath: OnPlayerGrappleHit.m_PersistentCalls.m_Calls.Array.data[0].m_Arguments.m_StringArgument
+      value: Hit!
+      objectReference: {fileID: 0}
+    - target: {fileID: 114402239207182064, guid: 982b977e0e8b71f4fb49001bc2fa0086,
+        type: 2}
+      propertyPath: OnPlayerGrappleRelease.m_PersistentCalls.m_Calls.Array.data[0].m_Mode
+      value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: 114402239207182064, guid: 982b977e0e8b71f4fb49001bc2fa0086,
+        type: 2}
+      propertyPath: OnPlayerGrappleRelease.m_PersistentCalls.m_Calls.Array.data[0].m_CallState
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 114402239207182064, guid: 982b977e0e8b71f4fb49001bc2fa0086,
+        type: 2}
+      propertyPath: OnPlayerGrappleRelease.m_PersistentCalls.m_Calls.Array.data[0].m_Target
+      value: 
+      objectReference: {fileID: 2107789480}
+    - target: {fileID: 114402239207182064, guid: 982b977e0e8b71f4fb49001bc2fa0086,
+        type: 2}
+      propertyPath: OnPlayerGrappleRelease.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
+      value: Log
+      objectReference: {fileID: 0}
+    - target: {fileID: 114402239207182064, guid: 982b977e0e8b71f4fb49001bc2fa0086,
+        type: 2}
+      propertyPath: OnPlayerGrappleRelease.m_PersistentCalls.m_Calls.Array.data[0].m_Arguments.m_ObjectArgumentAssemblyTypeName
+      value: UnityEngine.Object, UnityEngine
+      objectReference: {fileID: 0}
+    - target: {fileID: 114402239207182064, guid: 982b977e0e8b71f4fb49001bc2fa0086,
+        type: 2}
+      propertyPath: OnPlayerGrappleRelease.m_PersistentCalls.m_Calls.Array.data[0].m_Arguments.m_StringArgument
+      value: Release
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: 982b977e0e8b71f4fb49001bc2fa0086, type: 2}
@@ -952,6 +1201,11 @@ Prefab:
   m_Modification:
     m_TransformParent: {fileID: 0}
     m_Modifications:
+    - target: {fileID: 114373067657765630, guid: 354aebfb9f3934dfba7d06808a897841,
+        type: 2}
+      propertyPath: OnGrappleConnect.m_PersistentCalls.m_Calls.Array.size
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 4243135063600338, guid: 354aebfb9f3934dfba7d06808a897841, type: 2}
       propertyPath: m_LocalPosition.x
       value: -1.2523955
@@ -987,6 +1241,20 @@ Prefab:
     - target: {fileID: 1450384412150496, guid: 354aebfb9f3934dfba7d06808a897841, type: 2}
       propertyPath: m_Name
       value: GrapplePoint (2)
+      objectReference: {fileID: 0}
+    - target: {fileID: 114373067657765630, guid: 354aebfb9f3934dfba7d06808a897841,
+        type: 2}
+      propertyPath: OnGrappleConnect.m_PersistentCalls.m_Calls.Array.data[0].m_Mode
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 114373067657765630, guid: 354aebfb9f3934dfba7d06808a897841,
+        type: 2}
+      propertyPath: OnGrappleConnect.m_PersistentCalls.m_Calls.Array.data[0].m_CallState
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 1450384412150496, guid: 354aebfb9f3934dfba7d06808a897841, type: 2}
+      propertyPath: m_IsActive
+      value: 1
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: 354aebfb9f3934dfba7d06808a897841, type: 2}
@@ -1160,3 +1428,43 @@ Prefab:
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: ca37e0b2abe3b7a4484b7c84ec8f0889, type: 2}
   m_IsPrefabParent: 0
+--- !u!1 &2107789479
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 2107789481}
+  - component: {fileID: 2107789480}
+  m_Layer: 0
+  m_Name: DebugUtil
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &2107789480
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 2107789479}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c43dd1fb1c569404e8d3b9a2b36ab180, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!4 &2107789481
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 2107789479}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 6.645259, y: 2.4631157, z: -0.28424296}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 13
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}

--- a/385/Assets/Scripts/DebugPrinter.cs
+++ b/385/Assets/Scripts/DebugPrinter.cs
@@ -1,0 +1,15 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class DebugPrinter : MonoBehaviour
+{
+    /// <summary>
+    /// Exposes Debug.Log so that it can be called in a UnityEvent
+    /// </summary>
+    /// <param name="message"></param>
+    public void Log(string message)
+    {
+        Debug.Log(message);
+    }
+}

--- a/385/Assets/Scripts/DebugPrinter.cs.meta
+++ b/385/Assets/Scripts/DebugPrinter.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c43dd1fb1c569404e8d3b9a2b36ab180
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/385/Assets/Scripts/GrapplePointController.cs
+++ b/385/Assets/Scripts/GrapplePointController.cs
@@ -1,0 +1,22 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.Events;
+
+/// <summary>
+/// Controller class that has UnityEvents tied to actions associated
+/// with grapple point actions
+/// </summary>
+public class GrapplePointController : MonoBehaviour
+{
+    /// <summary>
+    /// Invoked when a grapple gets connected to this point
+    /// (this could be used to play a sound effect, or start a timer which can cause this point to self destruct)
+    /// </summary>
+    public UnityEvent OnGrappleConnect;
+
+    /// <summary>
+    /// Invoked when a grapple gets disconnected from this point
+    /// </summary>
+    public UnityEvent OnGrappleDisconnect;
+}

--- a/385/Assets/Scripts/GrapplePointController.cs.meta
+++ b/385/Assets/Scripts/GrapplePointController.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 33f333e8531478b4bbfbd4c2c628aaf8
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/385/Assets/Scripts/PlayerController.cs
+++ b/385/Assets/Scripts/PlayerController.cs
@@ -265,7 +265,7 @@ public class PlayerController : MonoBehaviour
     /// 
     /// TODO: When the player is at the top of a swing, should invert the swinging so that holding a direction
     /// doesn't do a full 360, but instead only goes in one direction.
-    /// Still need to nail down exactly how this logic would work
+    /// Still need to nail down exactly how this logic would work   
     /// </summary>
     private void UpdatePlayerSwingingForce()
     {

--- a/385/Assets/Scripts/PlayerController.cs
+++ b/385/Assets/Scripts/PlayerController.cs
@@ -367,7 +367,7 @@ public class PlayerController : MonoBehaviour
 
         // if not connected and not in deadzone
         // show the cursor
-        if (RopeSystem?.IsRopeConnected() == false && ( !joystickIsDead() || !ControllerMode))
+        if (RopeSystem?.IsRopeConnected() == false && ( !IsJoystickInDeadzone() || !ControllerMode))
         {
             // set the position of the aiming reticle
             AimingReticleObject.SetActive(true);
@@ -385,7 +385,7 @@ public class PlayerController : MonoBehaviour
 	/// <summary>
 	/// Checks if the joystick is in the deadzone. Currently used to know when to not display the reticle
 	/// </summary>
-	private bool joystickIsDead()
+	private bool IsJoystickInDeadzone()
 	{
 		float joystickX = Mathf.Abs(Input.GetAxis (AimHorizontalAxis));
 		float joystickY = Mathf.Abs(Input.GetAxis (AimVerticalAxis));

--- a/385/Assets/Scripts/RopeSystem.cs
+++ b/385/Assets/Scripts/RopeSystem.cs
@@ -224,8 +224,7 @@ public class RopeSystem : MonoBehaviour
 
             // not casting, if they hold down the button then cast
             if (FireButton.IsButtonHeld())
-            {
-                
+            {    
                 //HookCollider.enabled = true;
                 RopeAndHookCollider.enabled = true;
                 HookSpriteObject.SetActive(true);

--- a/385/Assets/Scripts/RopeSystem.cs
+++ b/385/Assets/Scripts/RopeSystem.cs
@@ -2,6 +2,7 @@
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
+using UnityEngine.Events;
 
 /// <summary>
 /// Script for controlling the behavior of a rope, which is connected to the player
@@ -121,6 +122,21 @@ public class RopeSystem : MonoBehaviour
     /// </summary>
     public GameObject HookSpriteObject;
 
+    /// <summary>
+    /// Invoked when the player fires thie Grappling hook
+    /// </summary>
+    public UnityEvent OnPlayerGrappleFire;
+
+    /// <summary>
+    /// Invoked when the players grappling hook hits an object
+    /// </summary>
+    public UnityEvent OnPlayerGrappleHit;
+
+    /// <summary>
+    /// Invoked when the player releases the grappling hook, even if it is connected or not
+    /// </summary>
+    public UnityEvent OnPlayerGrappleRelease;
+
     void Start()
     {
 		// Set axis strings based on the user's controller selection from the menu screen
@@ -209,6 +225,7 @@ public class RopeSystem : MonoBehaviour
             // not casting, if they hold down the button then cast
             if (FireButton.IsButtonHeld())
             {
+                
                 //HookCollider.enabled = true;
                 RopeAndHookCollider.enabled = true;
                 HookSpriteObject.SetActive(true);
@@ -258,6 +275,13 @@ public class RopeSystem : MonoBehaviour
 
                 // rotate the object that contains the casting collider
                 transform.rotation = Quaternion.Euler(0, 0, -90 + (Mathf.Rad2Deg * AimAngle));
+
+                // if they just clicked the fire button
+                if (FireButton.IsButtonClicked())
+                {
+                    // then invoke the on fire handler
+                    OnPlayerGrappleFire.Invoke();
+                }
             }
             // reset when let go
             else
@@ -321,6 +345,8 @@ public class RopeSystem : MonoBehaviour
         RopeAndHookCollider.enabled = false;
         IsCasting = false;
         CurrentCastDistance = 0;
+        // invoke the handler for the grapple point being released, unsure if it will block or not, so do this last
+        OnPlayerGrappleRelease.Invoke();
     }
 
     private bool HasDoneInitialReelIn = false;
@@ -355,6 +381,8 @@ public class RopeSystem : MonoBehaviour
         {
             IsCasting = false;
             Attach(collision.GetComponent<Rigidbody2D>());
+            // invoke the grapple hit
+            OnPlayerGrappleHit.Invoke();
         }
     }
 

--- a/385/Assets/Scripts/SwingUp/SwingUpController.cs
+++ b/385/Assets/Scripts/SwingUp/SwingUpController.cs
@@ -76,7 +76,7 @@ public class SwingUpController : MonoBehaviour
     /// <summary>
     /// The target position of the water level
     /// </summary>
-    private Vector3 WaterTargetPosition;
+    private Vector3 WaterTargetPosition = new Vector3(0, 0, 0);
 
     /// <summary>
     /// The position of the lower left bound to spawn objects
@@ -238,7 +238,7 @@ public class SwingUpController : MonoBehaviour
             Debug.Log($"Current rate : {(1f + MaxHeight / 30.0f) * WaterMoveRatePerSecond}");
         }
 
-        if (WaterTargetPosition != null && !LoseState)
+        if (!LoseState)
         {
             WaterReference.transform.position = Vector3.MoveTowards(WaterReference.transform.position, WaterTargetPosition, 0.2f);
         }            


### PR DESCRIPTION
Fixes #62 .

This PR adds support for UnityEvents which are invoked on common player actions. Use of UnityEvents means that adding new functionality can be kept in a separate file, and in general the whole thing is a lot nicer to work with.

This will make doing stuff like sounds much easier to maintain.

In addition, I've also adjusted some minor things like fixing warning messages and using better naming conventions.

Planned events to support:
- [x] On Player Jump
- [x] On Player Land (from a jump, or when they fall off a ledge)
- [x] On Player Grapple Fire
- [x] On Player Grapple Hit
- [x] On Player Grapple Release
- [x] On Grapple Point Connected
- [x] On Grapple Point Disconnected

(any others that might be useful)

Current Actual time: 90 min