### PR TITLE
Fix #82 Controller: rappeling axis back on D-Pad with lowered sensitivity

### DIFF
--- a/385/ProjectSettings/InputManager.asset
+++ b/385/ProjectSettings/InputManager.asset
@@ -110,12 +110,12 @@ InputManager:
     altNegativeButton: 
     altPositiveButton: 
     gravity: 3
-    dead: 0.4
-    sensitivity: 3
+    dead: 0.5
+    sensitivity: 1
     snap: 0
-    invert: 0
+    invert: 1
     type: 2
-    axis: 1
+    axis: 6
     joyNum: 0
   - serializedVersion: 3
     m_Name: Strafe_P2


### PR DESCRIPTION
Fixes #82 

I think this feels good. No longer has the issue of rappeling up/down wildly as you're trying to gain momentum swinging on a grapple point. Having swinging and rappeling controls both on the D-Pad is definitely more intuitive.

**Estimated: 10** **Min: 5** **Max: 15** **Actual: 15**
