### PR TITLE
Fix controller firing when in the deadzone

### DIFF
--- a/385/Assets/Scripts/PlayerController.cs
+++ b/385/Assets/Scripts/PlayerController.cs
@@ -409,6 +409,8 @@ public class PlayerController : MonoBehaviour
         // show the cursor
         if (RopeSystem?.IsRopeConnected() == false && ( !IsJoystickInDeadzone() || !ControllerMode))
         {
+            if (RopeSystem != null)
+                RopeSystem.CanFire = true;
             // set the position of the aiming reticle
             AimingReticleObject.SetActive(true);
             var position = new Vector3(Mathf.Cos(aimAngle) * AimingDistance, Mathf.Sin(aimAngle) * AimingDistance, 0);
@@ -417,6 +419,8 @@ public class PlayerController : MonoBehaviour
         }
         else
         {
+            if (RopeSystem != null)
+                RopeSystem.CanFire = false;
             // hide reticle
             AimingReticleObject.SetActive(false);
         }

--- a/385/Assets/Scripts/RopeSystem.cs
+++ b/385/Assets/Scripts/RopeSystem.cs
@@ -14,6 +14,13 @@ using UnityEngine.Events;
 public class RopeSystem : MonoBehaviour
 {
     /// <summary>
+    /// Toggle that determines if the rope system can fire out
+    /// This is disabled if the controller is in the deadzone, if a controller is being used
+    /// or when the grapple point is connected. This is set in PlayerController
+    /// </summary>
+    public bool CanFire = true;
+
+    /// <summary>
     /// The anchor point that the player's rope should be connected to,
     /// null if unset.
     /// </summary>
@@ -237,7 +244,8 @@ public class RopeSystem : MonoBehaviour
                 HookSpriteObject.SetActive(true);
 
                 // start throwing if not throwing already
-                if(!IsCasting)
+                // if they are allowed to fire
+                if(!IsCasting && CanFire)
                 {
                     // fireSound.Play();
                     IsCasting = true;


### PR DESCRIPTION
Fixes #81 .

Adds a toggle in `RopeController` that is set by the `PlayerController` so that when in Controller mode and the aiming is in the deadzone, pressing fire won't do anything.

Actual time: 15 min