### PR TITLE
Fix 109 Add more Unity Events

### DIFF
--- a/385/Assets/Prefabs/KillTrigger.prefab
+++ b/385/Assets/Prefabs/KillTrigger.prefab
@@ -40,7 +40,7 @@ GameObject:
   - component: {fileID: 114732769578851760}
   m_Layer: 0
   m_Name: KillTrigger
-  m_TagString: Untagged
+  m_TagString: Lava
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -121,6 +121,7 @@ SpriteRenderer:
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 4294967295
   m_Materials:
   - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
   m_StaticBatchInfo:
@@ -165,6 +166,7 @@ SpriteRenderer:
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 4294967295
   m_Materials:
   - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
   m_StaticBatchInfo:

--- a/385/Assets/Prefabs/LoseTriggerArea.prefab
+++ b/385/Assets/Prefabs/LoseTriggerArea.prefab
@@ -25,7 +25,7 @@ GameObject:
   - component: {fileID: 114833691015240784}
   m_Layer: 0
   m_Name: LoseTriggerArea
-  m_TagString: Untagged
+  m_TagString: Lava
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -56,6 +56,7 @@ MeshRenderer:
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 4294967295
   m_Materials:
   - {fileID: 2100000, guid: a0c0771f93e2b4d45a9a5dafb2aad0c0, type: 2}
   m_StaticBatchInfo:

--- a/385/Assets/Scenes/Level2.unity
+++ b/385/Assets/Scenes/Level2.unity
@@ -1315,7 +1315,7 @@ GameObject:
   - component: {fileID: 630823750}
   m_Layer: 0
   m_Name: Platform (6)
-  m_TagString: Floor & Wall
+  m_TagString: BouncyWall
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -1724,7 +1724,7 @@ GameObject:
   - component: {fileID: 850886636}
   m_Layer: 0
   m_Name: Platform (8)
-  m_TagString: Floor & Wall
+  m_TagString: BouncyWall
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -3078,7 +3078,7 @@ GameObject:
   - component: {fileID: 1495827251}
   m_Layer: 0
   m_Name: Platform (5)
-  m_TagString: Floor & Wall
+  m_TagString: BouncyWall
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -3175,7 +3175,7 @@ GameObject:
   - component: {fileID: 1497630316}
   m_Layer: 0
   m_Name: Platform (1)
-  m_TagString: Floor & Wall
+  m_TagString: BouncyWall
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -3538,7 +3538,7 @@ GameObject:
   - component: {fileID: 1931736056}
   m_Layer: 0
   m_Name: Platform (3)
-  m_TagString: Floor & Wall
+  m_TagString: BouncyWall
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -3985,7 +3985,7 @@ GameObject:
   - component: {fileID: 2079762112}
   m_Layer: 0
   m_Name: Platform (4)
-  m_TagString: Floor & Wall
+  m_TagString: BouncyWall
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -4082,7 +4082,7 @@ GameObject:
   - component: {fileID: 2098010215}
   m_Layer: 0
   m_Name: Platform (12)
-  m_TagString: Floor & Wall
+  m_TagString: BouncyWall
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0

--- a/385/Assets/Scenes/RealFinalTutorial.unity
+++ b/385/Assets/Scenes/RealFinalTutorial.unity
@@ -163,7 +163,7 @@ Prefab:
       objectReference: {fileID: 0}
     - target: {fileID: 1098079702230488, guid: 54034b0a4a13e084aa8b0b2d9e2791cd, type: 2}
       propertyPath: m_TagString
-      value: Ground
+      value: BouncyWall
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: 54034b0a4a13e084aa8b0b2d9e2791cd, type: 2}
@@ -1460,6 +1460,10 @@ Prefab:
         type: 2}
       propertyPath: m_RootOrder
       value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 1478081047187256, guid: 3102f46f6380f468897d9dc963dd0cfe, type: 2}
+      propertyPath: m_IsActive
+      value: 1
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: 3102f46f6380f468897d9dc963dd0cfe, type: 2}
@@ -2933,6 +2937,10 @@ Prefab:
     - target: {fileID: 4279929632844612, guid: 54034b0a4a13e084aa8b0b2d9e2791cd, type: 2}
       propertyPath: m_LocalScale.x
       value: 0.33655268
+      objectReference: {fileID: 0}
+    - target: {fileID: 1098079702230488, guid: 54034b0a4a13e084aa8b0b2d9e2791cd, type: 2}
+      propertyPath: m_TagString
+      value: BouncyWall
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: 54034b0a4a13e084aa8b0b2d9e2791cd, type: 2}

--- a/385/Assets/Scenes/TutorialFinal.unity
+++ b/385/Assets/Scenes/TutorialFinal.unity
@@ -778,7 +778,7 @@ GameObject:
   - component: {fileID: 155564461}
   m_Layer: 0
   m_Name: Platform (4)
-  m_TagString: Floor & Wall
+  m_TagString: BouncyWall
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -3176,7 +3176,7 @@ GameObject:
   - component: {fileID: 1487514419}
   m_Layer: 0
   m_Name: Platform (3)
-  m_TagString: Floor & Wall
+  m_TagString: BouncyWall
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -4347,7 +4347,7 @@ GameObject:
   - component: {fileID: 1998887986}
   m_Layer: 0
   m_Name: Platform (1)
-  m_TagString: Floor & Wall
+  m_TagString: BouncyWall
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0

--- a/385/Assets/Scripts/PlayerController.cs
+++ b/385/Assets/Scripts/PlayerController.cs
@@ -143,6 +143,26 @@ public class PlayerController : MonoBehaviour
     /// </summary>
     public UnityEvent OnPlayerLand;
 
+    /// <summary>
+    /// Set of methods to call when the player interacts with <see cref="Tags.TAG_LAVA"/>
+    /// </summary>
+    public UnityEvent OnPlayerLavaCollide;
+
+    /// <summary>
+    /// set of methods to call when the player interacts with <see cref="Tags.TAG_FLOOR_WALL"/>
+    /// </summary>
+    public UnityEvent OnPlayerWallCollide;
+
+    /// <summary>
+    /// set of methods to call when the player interacts with <see cref="Tags.TAG_BOUNCY_WALL"/>
+    /// </summary>
+    public UnityEvent OnPlayerBouncyWallCollide;
+
+    /// <summary>
+    /// set of methods to call when the player interacts with <see cref="Tags.TAG_GROUND_DIS"/> or <see cref="Tags.TAG_GROUND_TIMED"/>
+    /// </summary>
+    public UnityEvent OnPlayerDisappearingPlatformCollide;
+
 
     // Use this for initialization
     void Start ()
@@ -190,6 +210,12 @@ public class PlayerController : MonoBehaviour
         if (collide.gameObject.tag == Tags.TAG_GROUND || collide.gameObject.tag == Tags.TAG_GROUND_DIS
             || collide.gameObject.tag == Tags.TAG_GROUND_TIMED)
         {
+            // invoke the handler for a platform that will disappear
+            if (collide.gameObject.CompareTag(Tags.TAG_GROUND_TIMED) || collide.gameObject.CompareTag(Tags.TAG_GROUND_DIS))
+            {
+                OnPlayerDisappearingPlatformCollide.Invoke();
+            }
+
             // if the player wasn't previously on the ground
             // then they likely just landed a jump
             if (!onGround)
@@ -208,6 +234,21 @@ public class PlayerController : MonoBehaviour
         else if (collide.gameObject.tag == Tags.TAG_GRAPPLE_HOOK)
         {
             // Debug.Log("Oh no this player was hit with a grapple hook!");
+        }
+        // when the player collides with a bouncy wall, invoke the bouncy wall handler
+        else if (collide.gameObject.CompareTag(Tags.TAG_BOUNCY_WALL))
+        {
+            OnPlayerBouncyWallCollide.Invoke();
+        }
+        // when the player collides with lava, invoke the lava collide handler
+        else if (collide.gameObject.CompareTag(Tags.TAG_LAVA))
+        {
+            OnPlayerLavaCollide.Invoke();
+        }
+        // when the player collides with a regular ol' wall, invoke the wall collide handler
+        else if (collide.gameObject.CompareTag(Tags.TAG_FLOOR_WALL))
+        {
+            OnPlayerWallCollide.Invoke();
         }
     }
 

--- a/385/Assets/Scripts/RopeSystem.cs
+++ b/385/Assets/Scripts/RopeSystem.cs
@@ -157,6 +157,16 @@ public class RopeSystem : MonoBehaviour
     /// </summary>
     public UnityEvent OnPlayerGrappleRelease;
 
+    /// <summary>
+    /// Invoked when the player interacts with a crumbly grapple point
+    /// </summary>
+    public UnityEvent OnPlayerCrumblyGrapplePointConnect;
+
+    /// <summary>
+    /// Invoked when the player interacts with a regular and non-crumbly grapple point
+    /// </summary>
+    public UnityEvent OnPlayerSturdyGrapplePointConnect;
+
     void Start()
     {
         // Set axis strings based on the user's controller selection from the menu screen
@@ -353,7 +363,9 @@ public class RopeSystem : MonoBehaviour
             // check that we collided with any of the world tags
             if (lastHit.collider.CompareTag(Tags.TAG_FLOOR_WALL) ||
                 lastHit.collider.CompareTag(Tags.TAG_GROUND) ||
-                lastHit.collider.CompareTag(Tags.TAG_GROUND_DIS))
+                lastHit.collider.CompareTag(Tags.TAG_GROUND_DIS) ||
+                lastHit.collider.CompareTag(Tags.TAG_BOUNCY_WALL) ||
+                lastHit.collider.CompareTag(Tags.TAG_LAVA))
             {
                 // if we did, then prevent extending into these
                 return false;
@@ -519,6 +531,17 @@ public class RopeSystem : MonoBehaviour
         {
             IsCasting = false;
             Attach(collision.GetComponent<Rigidbody2D>(), collision.GetComponent<GrapplePointController>());
+
+            // if the collided component has a Disappearing Controller
+            // then invoke the handler for when the player connects with the crumbling controller
+            if (collision.GetComponent<CrumblingGrapplePointController>() != null)
+            {
+                OnPlayerCrumblyGrapplePointConnect.Invoke();
+            }
+            // otherwise invoke the usual handler
+            else
+                OnPlayerSturdyGrapplePointConnect.Invoke();
+
             // invoke the grapple hit
             OnPlayerGrappleHit.Invoke();
         }

--- a/385/Assets/Scripts/Tags.cs
+++ b/385/Assets/Scripts/Tags.cs
@@ -15,5 +15,7 @@ public static class Tags
     public const string TAG_GROUND_DIS = "GroundDis";
     public const string TAG_GROUND_TIMED = "GroundTimed";
     public const string TAG_GRAPPLE_POINT = "GrapplePoint";
-	public const string TAG_GRAPPLE_HOOK = "GrappleHook";    
+	public const string TAG_GRAPPLE_HOOK = "GrappleHook";
+    public const string TAG_BOUNCY_WALL = "BouncyWall";
+    public const string TAG_LAVA = "Lava";
 }

--- a/385/ProjectSettings/TagManager.asset
+++ b/385/ProjectSettings/TagManager.asset
@@ -9,6 +9,9 @@ TagManager:
   - GrapplePoint
   - GrappleHook
   - GroundDis
+  - GroundTimed
+  - Lava
+  - BouncyWall
   layers:
   - Default
   - TransparentFX


### PR DESCRIPTION
Adds more `UnityEvent`s for when the player collides with the bouncy platforms, the lava, and the walls.
Updates the scenes to include more tags and updates the platforms in those scenes to use the tags

While I was at it, I also added handlers for when the player lands on a crumbling platform, connects to a regular sturdy grapple point and when the player connects to an unstable crumbling grapple point, since I could see sounds being associated with all of these.